### PR TITLE
Update KSP plugin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     id("com.google.dagger.hilt.android") version "2.56.2" apply false
-    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
+    id("com.google.devtools.ksp") version "2.1.20-1.0.32" apply false
 }


### PR DESCRIPTION
## Summary
- update KSP plugin to 2.1.20-1.0.32

## Testing
- `./gradlew :app:kspDebugKotlin --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852829c88d4832aace7da15dd800bf0