### PR TITLE
Implement schedule screen with SportMonks API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,11 @@ dependencies {
     // Coroutines
     implementation(libs.kotlinx.coroutines.android)
 
+    // Retrofit
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.14")
+
     kapt(libs.androidx.room.compiler)
 
     // Тесты

--- a/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
+++ b/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
@@ -1,0 +1,15 @@
+package com.pinup.barapp.data.remote
+
+import com.pinup.barapp.data.remote.dto.MatchResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ApiService {
+    @GET("fixtures/between")
+    suspend fun getMatchesNext7Days(
+        @Query("from") fromDate: String,
+        @Query("to") toDate: String,
+        @Query("api_token") apiKey: String
+    ): Response<MatchResponse>
+}

--- a/app/src/main/java/com/pinup/barapp/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/pinup/barapp/data/remote/RetrofitClient.kt
@@ -1,4 +1,27 @@
 package com.pinup.barapp.data.remote
 
-class RetrofitClient {
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object RetrofitClient {
+    private const val BASE_URL = "https://api.sportmonks.com/v3/football/"
+    const val API_KEY = "demo" // replace with real key if available
+
+    val apiService: ApiService by lazy {
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor(logging)
+            .build()
+
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ApiService::class.java)
+    }
 }

--- a/app/src/main/java/com/pinup/barapp/data/remote/dto/MatchDto.kt
+++ b/app/src/main/java/com/pinup/barapp/data/remote/dto/MatchDto.kt
@@ -1,0 +1,37 @@
+package com.pinup.barapp.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+import com.pinup.barapp.domain.models.Match
+
+data class MatchResponse(
+    @SerializedName("data") val data: List<MatchDto>
+)
+
+data class MatchDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("starting_at") val startingAt: String?,
+    @SerializedName("status") val status: String?,
+    @SerializedName("league") val league: LeagueDto?,
+    @SerializedName("home_team") val homeTeam: TeamDto?,
+    @SerializedName("away_team") val awayTeam: TeamDto?
+) {
+    fun toDomain(): Match = Match(
+        id = id,
+        homeName = homeTeam?.name.orEmpty(),
+        awayName = awayTeam?.name.orEmpty(),
+        homeLogo = homeTeam?.logo,
+        awayLogo = awayTeam?.logo,
+        time = startingAt.orEmpty(),
+        status = status.orEmpty(),
+        league = league?.name.orEmpty()
+    )
+}
+
+data class TeamDto(
+    @SerializedName("name") val name: String?,
+    @SerializedName("image_path") val logo: String?
+)
+
+data class LeagueDto(
+    @SerializedName("name") val name: String?
+)

--- a/app/src/main/java/com/pinup/barapp/data/repositories/MatchRepositoryImpl.kt
+++ b/app/src/main/java/com/pinup/barapp/data/repositories/MatchRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.pinup.barapp.data.repositories
+
+import com.pinup.barapp.data.remote.ApiService
+import com.pinup.barapp.data.remote.RetrofitClient
+import com.pinup.barapp.domain.MatchRepository
+import com.pinup.barapp.domain.models.Match
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class MatchRepositoryImpl @Inject constructor(
+    private val api: ApiService
+) : MatchRepository {
+
+    override suspend fun getUpcomingMatches(): List<Match> {
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val from = LocalDate.now()
+        val to = from.plusDays(7)
+        return try {
+            val response = api.getMatchesNext7Days(
+                formatter.format(from),
+                formatter.format(to),
+                RetrofitClient.API_KEY
+            )
+            if (response.isSuccessful) {
+                response.body()?.data?.map { it.toDomain() } ?: emptyList()
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/pinup/barapp/di/NetworkModule.kt
+++ b/app/src/main/java/com/pinup/barapp/di/NetworkModule.kt
@@ -1,0 +1,24 @@
+package com.pinup.barapp.di
+
+import com.pinup.barapp.data.remote.ApiService
+import com.pinup.barapp.data.remote.RetrofitClient
+import com.pinup.barapp.data.repositories.MatchRepositoryImpl
+import com.pinup.barapp.domain.MatchRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideApiService(): ApiService = RetrofitClient.apiService
+
+    @Provides
+    @Singleton
+    fun provideMatchRepository(api: ApiService): MatchRepository = MatchRepositoryImpl(api)
+}

--- a/app/src/main/java/com/pinup/barapp/domain/MatchRepository.kt
+++ b/app/src/main/java/com/pinup/barapp/domain/MatchRepository.kt
@@ -1,0 +1,7 @@
+package com.pinup.barapp.domain
+
+import com.pinup.barapp.domain.models.Match
+
+interface MatchRepository {
+    suspend fun getUpcomingMatches(): List<Match>
+}

--- a/app/src/main/java/com/pinup/barapp/domain/models/Match.kt
+++ b/app/src/main/java/com/pinup/barapp/domain/models/Match.kt
@@ -1,0 +1,12 @@
+package com.pinup.barapp.domain.models
+
+data class Match(
+    val id: Int,
+    val homeName: String,
+    val awayName: String,
+    val homeLogo: String?,
+    val awayLogo: String?,
+    val time: String,
+    val status: String,
+    val league: String
+)

--- a/app/src/main/java/com/pinup/barapp/ui/adapters/ScheduleAdapter.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/adapters/ScheduleAdapter.kt
@@ -1,0 +1,49 @@
+package com.pinup.barapp.ui.adapters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.pinup.barapp.R
+import com.pinup.barapp.domain.models.Match
+
+class ScheduleAdapter : ListAdapter<Match, ScheduleAdapter.MatchViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MatchViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_schedule, parent, false)
+        return MatchViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MatchViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class MatchViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val homeName = view.findViewById<TextView>(R.id.tvHomeName)
+        private val awayName = view.findViewById<TextView>(R.id.tvAwayName)
+        private val league = view.findViewById<TextView>(R.id.tvLeague)
+        private val time = view.findViewById<TextView>(R.id.tvTime)
+        private val status = view.findViewById<TextView>(R.id.tvStatus)
+        private val homeLogo = view.findViewById<ImageView>(R.id.ivHomeLogo)
+        private val awayLogo = view.findViewById<ImageView>(R.id.ivAwayLogo)
+
+        fun bind(match: Match) {
+            homeName.text = match.homeName
+            awayName.text = match.awayName
+            league.text = match.league
+            time.text = match.time
+            status.text = match.status
+            // For simplicity we skip image loading libraries
+        }
+    }
+
+    class DiffCallback : DiffUtil.ItemCallback<Match>() {
+        override fun areItemsTheSame(oldItem: Match, newItem: Match): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Match, newItem: Match): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
@@ -1,60 +1,48 @@
 package com.pinup.barapp.ui.fragments
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.pinup.barapp.R
+import com.pinup.barapp.databinding.FragmentScheduleBinding
+import com.pinup.barapp.ui.adapters.ScheduleAdapter
+import com.pinup.barapp.ui.viewmodels.ScheduleViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
+@AndroidEntryPoint
+class ScheduleFragment : Fragment(R.layout.fragment_schedule) {
 
-/**
- * A simple [Fragment] subclass.
- * Use the [ScheduleFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
-class ScheduleFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
+    private var _binding: FragmentScheduleBinding? = null
+    private val binding get() = _binding!!
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
+    private val viewModel: ScheduleViewModel by viewModels()
+    private lateinit var adapter: ScheduleAdapter
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_schedule, container, false)
+    ): View {
+        _binding = FragmentScheduleBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ScheduleFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ScheduleFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        adapter = ScheduleAdapter()
+        binding.recyclerSchedule.adapter = adapter
+
+        viewModel.matches.observe(viewLifecycleOwner) { list ->
+            adapter.submitList(list)
+        }
+        viewModel.loadMatches()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/com/pinup/barapp/ui/viewmodels/ScheduleViewModel.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/viewmodels/ScheduleViewModel.kt
@@ -1,0 +1,26 @@
+package com.pinup.barapp.ui.viewmodels
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.pinup.barapp.domain.MatchRepository
+import com.pinup.barapp.domain.models.Match
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ScheduleViewModel @Inject constructor(
+    private val repository: MatchRepository
+) : ViewModel() {
+
+    private val _matches = MutableLiveData<List<Match>>()
+    val matches: LiveData<List<Match>> = _matches
+
+    fun loadMatches() {
+        viewModelScope.launch {
+            _matches.value = repository.getUpcomingMatches()
+        }
+    }
+}

--- a/app/src/main/res/layout/item_schedule.xml
+++ b/app/src/main/res/layout/item_schedule.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvLeague"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="14sp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingTop="4dp">
+
+        <ImageView
+            android:id="@+id/ivHomeLogo"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="4dp"/>
+
+        <TextView
+            android:id="@+id/tvHomeName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="vs"/>
+
+        <TextView
+            android:id="@+id/tvAwayName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="end"/>
+
+        <ImageView
+            android:id="@+id/ivAwayLogo"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="4dp"/>
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/tvTime"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:paddingTop="2dp"/>
+
+    <TextView
+        android:id="@+id/tvStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:paddingBottom="4dp"/>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add Retrofit dependencies
- configure `RetrofitClient` and `ApiService`
- map API data into `Match` domain model
- implement `MatchRepositoryImpl`
- create `ScheduleViewModel`, `ScheduleAdapter`, and update fragment
- add DI module for new network layer
- provide item layout for match rows

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b459c5fc832ab694916325468302