### PR TITLE
Add background blur when opening Help dialog

### DIFF
--- a/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import eightbitlab.com.blurview.BlurView
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pinup.barapp.R
@@ -15,6 +16,19 @@ import com.pinup.barapp.ui.MainActivity
 class BlankFragment : Fragment() {
 
     private lateinit var binding: FragmentBlankBinding
+
+    private fun showBlur(show: Boolean) {
+        val blurView = binding.blurView
+        if (show) {
+            val rootView = requireActivity().window.decorView.findViewById<ViewGroup>(android.R.id.content).getChildAt(0) as ViewGroup
+            blurView.setupWith(rootView)
+                .setBlurRadius(16f)
+                .setOverlayColor(0x99FFFFFF.toInt())
+            blurView.visibility = View.VISIBLE
+        } else {
+            blurView.visibility = View.GONE
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -31,7 +45,9 @@ class BlankFragment : Fragment() {
         cardsListener()
 
         binding.btnContact.setOnClickListener {
-            HelpDialogFragment().show(parentFragmentManager, "HelpDialog")
+            showBlur(true)
+            HelpDialogFragment { showBlur(false) }
+                .show(parentFragmentManager, "HelpDialog")
         }
 
 

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/HelpDialogFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/HelpDialogFragment.kt
@@ -3,34 +3,12 @@ import android.os.Bundle
 import android.view.*
 import androidx.fragment.app.DialogFragment
 import com.pinup.barapp.databinding.DialogHelpBinding
-import android.graphics.RenderEffect
-import android.graphics.Shader
-import android.os.Build
 import com.pinup.barapp.R
-import eightbitlab.com.blurview.BlurView
-import eightbitlab.com.blurview.RenderScriptBlur
 
 
-class HelpDialogFragment : DialogFragment() {
+class HelpDialogFragment(private val onDismissCallback: (() -> Unit)? = null) : DialogFragment() {
     private var _binding: DialogHelpBinding? = null
     private val binding get() = _binding!!
-
-    private fun showBlur(show: Boolean) {
-        val blurView = requireActivity().findViewById<BlurView>(R.id.blurView)
-        if (show) {
-            // Настраиваем blurView для overlay
-            val rootView = requireActivity().window.decorView.findViewById<ViewGroup>(android.R.id.content).getChildAt(0) as ViewGroup
-            blurView.setupWith(rootView)
-//                .setBlurAlgorithm(RenderScriptBlur(requireContext()))
-                .setBlurRadius(16f)
-                .setOverlayColor(0x99FFFFFF.toInt())
-//                .setHasFixedTransformationMatrix(true)
-            blurView.visibility = View.VISIBLE
-
-        } else {
-            blurView.visibility = View.GONE
-        }
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -41,7 +19,6 @@ class HelpDialogFragment : DialogFragment() {
 
     override fun onStart() {
         super.onStart()
-        showBlur(true)
         dialog?.window?.setLayout(
             (resources.displayMetrics.widthPixels * 0.85).toInt(),
             WindowManager.LayoutParams.WRAP_CONTENT
@@ -51,8 +28,8 @@ class HelpDialogFragment : DialogFragment() {
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        showBlur(false)
         super.onDismiss(dialog)
+        onDismissCallback?.invoke()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Summary
- add blur overlay logic in `BlankFragment`
- handle dismiss callback in `HelpDialogFragment`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d1e99ae8832a8e0ed0841ee32975