### PR TITLE
Fix blur overlay setup

### DIFF
--- a/app/src/main/java/com/pinup/barapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/MainActivity.kt
@@ -1,17 +1,36 @@
 package com.pinup.barapp.ui
 
+import android.graphics.drawable.Drawable
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.pinup.barapp.R
+import eightbitlab.com.blurview.BlurView
+import eightbitlab.com.blurview.RenderScriptBlur
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+    private lateinit var blurView: BlurView
+
+    fun showBlur() {
+        blurView.visibility = android.view.View.VISIBLE
+    }
+
+    fun hideBlur() {
+        blurView.visibility = android.view.View.GONE
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        blurView = findViewById(R.id.blurView)
+        val rootView = findViewById<ViewGroup>(android.R.id.content)
+        val windowBackground: Drawable = window.decorView.background
+        blurView.setupWith(rootView, RenderScriptBlur(this))
+            .setFrameClearDrawable(windowBackground)
+            .setBlurRadius(16f)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
@@ -1,6 +1,5 @@
 package com.pinup.barapp.ui.fragments
 
-import HelpDialogFragment
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -31,6 +30,7 @@ class BlankFragment : Fragment() {
         cardsListener()
 
         binding.btnContact.setOnClickListener {
+            (activity as? MainActivity)?.showBlur()
             HelpDialogFragment().show(parentFragmentManager, "HelpDialog")
         }
 

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/HelpDialogFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/HelpDialogFragment.kt
@@ -1,7 +1,47 @@
+package com.pinup.barapp.ui.fragments
+
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import com.pinup.barapp.databinding.DialogHelpBinding
+import com.pinup.barapp.ui.MainActivity
 
 class HelpDialogFragment : DialogFragment() {
     private var _binding: DialogHelpBinding? = null
     private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DialogHelpBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(
+            (resources.displayMetrics.widthPixels * 0.85).toInt(),
+            WindowManager.LayoutParams.WRAP_CONTENT,
+        )
+        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
+        dialog?.window?.setGravity(Gravity.CENTER)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        (activity as? MainActivity)?.hideBlur()
+    }
 }
+

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,7 +16,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <eightbitlab.com.blurview.BlurView
+        android:id="@+id/blurView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
         app:layout_constraintTop_toTopOf="parent"
-    />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- clean up blur view setup to use available methods
- tidy blank fragment imports
- add missing package declaration for `HelpDialogFragment`
- correct dialog appearance by sizing window and making background transparent

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685736f063a4832ab84863763c819659