### PR TITLE
Handle bottom navigation globally

### DIFF
--- a/app/src/main/java/com/pinup/barapp/ui/fragments/BasketFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/BasketFragment.kt
@@ -7,10 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pinup.barapp.R
 import com.pinup.barapp.databinding.FragmentBasketBinding
-import com.pinup.barapp.ui.MainActivity
 import com.pinup.barapp.ui.adapters.CartAdapter
 import com.pinup.barapp.ui.viewmodels.CartViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,8 +30,6 @@ class BasketFragment : Fragment(R.layout.fragment_basket) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.GONE
-
         adapter = CartAdapter(
             onIncrease = { cartViewModel.increaseQuantity(it) },
             onDecrease = { cartViewModel.decreaseQuantity(it) },
@@ -62,7 +58,6 @@ class BasketFragment : Fragment(R.layout.fragment_basket) {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.VISIBLE
         _binding = null
     }
 }

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/BlankFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pinup.barapp.R
 import com.pinup.barapp.databinding.FragmentBlankBinding
 import com.pinup.barapp.ui.MainActivity
@@ -25,8 +24,6 @@ class BlankFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.GONE
-
         cardsListener()
 
         binding.btnContact.setOnClickListener {
@@ -39,7 +36,6 @@ class BlankFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.VISIBLE
     }
 
     private fun cardsListener() {

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/HomePinupFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/HomePinupFragment.kt
@@ -33,6 +33,16 @@ class HomePinupFragment : Fragment() {
         binding.bottomNavigation.setupWithNavController(navController)
         binding.bottomNavigation.selectedItemId = R.id.menuFragment
 
+        navController.addOnDestinationChangedListener { _, destination, _ ->
+            when (destination.id) {
+                R.id.blankFragment,
+                R.id.basketFragment,
+                R.id.QRFragment,
+                R.id.reservationQrFragment -> binding.bottomNavigation.visibility = View.GONE
+                else -> binding.bottomNavigation.visibility = View.VISIBLE
+            }
+        }
+
 
     }
 }

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/QrFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/QrFragment.kt
@@ -7,12 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
 import com.pinup.barapp.R
 import com.pinup.barapp.databinding.FragmentQrBinding
-import com.pinup.barapp.ui.MainActivity
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.set
 import androidx.navigation.fragment.findNavController
@@ -33,7 +31,6 @@ class QRFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.GONE
         // Генерируем QR-код с orderId или уникальным текстом
         val orderId = args.orderId
         val qrBitmap = generateQRCode(orderId)
@@ -49,7 +46,6 @@ class QRFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.VISIBLE
         _binding = null
     }
 

--- a/app/src/main/java/com/pinup/barapp/ui/fragments/ReservationQrFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/ReservationQrFragment.kt
@@ -9,12 +9,10 @@ import androidx.core.graphics.createBitmap
 import androidx.core.graphics.set
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
 import com.pinup.barapp.R
 import com.pinup.barapp.databinding.FragmentReservationQrBinding
-import com.pinup.barapp.ui.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -33,7 +31,6 @@ class ReservationQrFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.GONE
         val reservationId = "2849"
         val qrBitmap = generateQRCode(reservationId)
         binding.ivQr.setImageBitmap(qrBitmap)
@@ -46,7 +43,6 @@ class ReservationQrFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? MainActivity)?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.visibility = View.VISIBLE
         _binding = null
     }
 


### PR DESCRIPTION
## Summary
- hide the bottom navigation for particular destinations using a listener
- remove fragment-specific bottom nav handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857456df654832a8c7354d6e4c0d73e