### PR TITLE
Fix ApiService path and add request test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     testImplementation(libs.androidx.room.testing)
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:5.0.0-alpha.14")
 
     implementation("com.google.zxing:core:3.4.1")
     implementation ("jp.wasabeef:blurry:4.0.1")

--- a/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
+++ b/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Query
 
 interface ApiService {
 
-    @GET("fixtures/between/{from}/{to}?include=participants;participants.meta;league")
+    @GET("fixtures/between/{from}/{to}")
     suspend fun getMatchesNext7Days(
         @Path("from") fromDate: String,
         @Path("to") toDate: String,

--- a/app/src/test/java/com/pinup/barapp/ApiServiceTest.kt
+++ b/app/src/test/java/com/pinup/barapp/ApiServiceTest.kt
@@ -1,0 +1,62 @@
+import com.pinup.barapp.BuildConfig
+import com.pinup.barapp.data.remote.ApiService
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class ApiServiceTest {
+    private lateinit var server: MockWebServer
+    private lateinit var api: ApiService
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        val logging = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val original = chain.request()
+                val url = original.url.newBuilder()
+                    .addQueryParameter("api_token", BuildConfig.API_KEY)
+                    .build()
+                val request = original.newBuilder().url(url).build()
+                chain.proceed(request)
+            }
+            .addInterceptor(logging)
+            .build()
+
+        api = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ApiService::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun requestPathContainsQueryParams() = runBlocking {
+        server.enqueue(MockResponse().setBody("{\"data\":[]}"))
+
+        api.getMatchesNext7Days("2024-01-01", "2024-01-08")
+
+        val recorded = server.takeRequest()
+        assertEquals(
+            "/fixtures/between/2024-01-01/2024-01-08?api_token=${BuildConfig.API_KEY}&include=participants;league",
+            recorded.path
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- remove hard-coded query params from ApiService
- check the request path via MockWebServer
- include MockWebServer test dependency

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685759343ef0832a8ac5315750a46da7