### PR TITLE
Fix API call signature

### DIFF
--- a/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
+++ b/app/src/main/java/com/pinup/barapp/data/remote/ApiService.kt
@@ -8,11 +8,10 @@ import retrofit2.http.Query
 
 interface ApiService {
 
-    @GET("fixtures/between/{from}/{to}?include=participants;participants.meta;league")
+    @GET("fixtures/between/{from}/{to}")
     suspend fun getMatchesNext7Days(
         @Path("from") fromDate: String,
         @Path("to") toDate: String,
-        @Query("api_token") apiKey: String,
         @Query("include") include: String = "participants;league"
     ): Response<MatchResponse>
 


### PR DESCRIPTION
## Summary
- remove duplicated query params from ApiService

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575db2ca4c832ababe8c01601b1307