### PR TITLE
Add match range retrieval

### DIFF
--- a/app/src/main/java/com/pinup/barapp/data/repositories/MatchRepositoryImpl.kt
+++ b/app/src/main/java/com/pinup/barapp/data/repositories/MatchRepositoryImpl.kt
@@ -12,15 +12,13 @@ class MatchRepositoryImpl @Inject constructor(
     private val api: ApiService
 ) : MatchRepository {
 
-    override suspend fun getUpcomingMatches(): List<Match> {
-        val from = LocalDate.now()
-        val to = from.plusDays(7)
+    override suspend fun getMatchesBetween(start: LocalDate, end: LocalDate): List<Match> {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
         return try {
             val response = api.getMatchesNext7Days(
-                formatter.format(from),
-                formatter.format(to)
+                formatter.format(start),
+                formatter.format(end)
             )
             if (response.isSuccessful) {
                 response.body()?.data?.map { it.toDomain() } ?: emptyList()
@@ -30,5 +28,11 @@ class MatchRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             emptyList()
         }
+    }
+
+    override suspend fun getUpcomingMatches(): List<Match> {
+        val from = LocalDate.now()
+        val to = from.plusDays(7)
+        return getMatchesBetween(from, to)
     }
 }

--- a/app/src/main/java/com/pinup/barapp/domain/MatchRepository.kt
+++ b/app/src/main/java/com/pinup/barapp/domain/MatchRepository.kt
@@ -1,7 +1,10 @@
 package com.pinup.barapp.domain
 
 import com.pinup.barapp.domain.models.Match
+import java.time.LocalDate
 
 interface MatchRepository {
     suspend fun getUpcomingMatches(): List<Match>
+
+    suspend fun getMatchesBetween(start: LocalDate, end: LocalDate): List<Match>
 }


### PR DESCRIPTION
## Summary
- expand `MatchRepository` with `getMatchesBetween`
- implement date range logic in `MatchRepositoryImpl`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576465807c832ab70f2dd3a65dc467