### PR TITLE
Add month spinner to Schedule fragment

### DIFF
--- a/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
+++ b/app/src/main/java/com/pinup/barapp/ui/fragments/ScheduleFragment.kt
@@ -44,10 +44,10 @@ class ScheduleFragment : Fragment(R.layout.fragment_schedule) {
         val months = Month.values().map { it.getDisplayName(TextStyle.FULL, Locale.US) }
         val spinnerAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, months)
         spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        binding.spinnerMonth.adapter = spinnerAdapter
-        binding.spinnerMonth.setSelection(LocalDate.now().monthValue - 1)
+        binding.tvMonth.adapter = spinnerAdapter
+        binding.tvMonth.setSelection(LocalDate.now().monthValue - 1)
 
-        binding.spinnerMonth.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        binding.tvMonth.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
                 val month = Month.of(position + 1)
                 viewModel.loadMatchesForMonth(month)

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -79,7 +79,7 @@
         app:layout_constraintEnd_toEndOf="parent">
 
         <Spinner
-            android:id="@+id/spinnerMonth"
+            android:id="@+id/tvMonth"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:spinnerMode="dropdown"
@@ -93,10 +93,10 @@
             android:layout_height="1dp"
             android:layout_marginStart="8dp"
             android:background="#00A264"
-            app:layout_constraintStart_toEndOf="@id/spinnerMonth"
+            app:layout_constraintStart_toEndOf="@id/tvMonth"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/spinnerMonth"
-            app:layout_constraintBottom_toBottomOf="@id/spinnerMonth"/>
+            app:layout_constraintTop_toTopOf="@id/tvMonth"
+            app:layout_constraintBottom_toBottomOf="@id/tvMonth"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
## Summary
- turn the month selector into a `Spinner` with id `tvMonth`
- update `ScheduleFragment` to use the new spinner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a34db4b8832a95557cd653616428